### PR TITLE
Restore auto race toggle in Legend of Speed module

### DIFF
--- a/258258996.lua
+++ b/258258996.lua
@@ -1,0 +1,517 @@
+--[[
+    Miner's Haven automation module.  This script extracts only the portions
+    of the original RevampLua file that are required when the loader detects
+    we are inside Miner's Haven (PlaceId 258258996).
+
+    The module keeps the public surface compatible with the previous
+    `Revamp` table so other scripts can migrate gradually while the monolithic
+    source is being retired.
+]]
+
+local Players = game:GetService("Players")
+local RunService = game:GetService("RunService")
+local PathfindingService = game:GetService("PathfindingService")
+local UserInputService = game:GetService("UserInputService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local LocalPlayer = Players.LocalPlayer
+
+local MinersHaven = {
+    PlaceId = 258258996,
+    Services = {
+        Players = Players,
+        RunService = RunService,
+        PathfindingService = PathfindingService,
+        UserInputService = UserInputService,
+        ReplicatedStorage = ReplicatedStorage,
+    },
+    Data = {
+        SafeZones = {},
+        LayoutCosts = {},
+        Items = {},
+        Evolved = {},
+    },
+    State = {
+        collectBoxes = false,
+        autoOpenBoxes = false,
+        collectClovers = false,
+        legitPathing = false,
+        autoRebirth = false,
+    },
+    Modules = {
+        Utilities = {},
+        Pathing = {},
+        Combat = {},
+        Farming = {},
+        Inventory = {},
+        Logging = {},
+    },
+    UI = {
+        instances = {},
+    },
+}
+
+---------------------------------------------------------------------
+-- Local cache and convenience references
+---------------------------------------------------------------------
+
+local MoneyLibrary = nil
+local FetchItemModule = nil
+local touchedMHBoxes = {}
+local LegitPathing = false
+local pathfindingBusy = false
+local humanoid
+local humanoidRoot
+
+local function ensureLibraries()
+    if not FetchItemModule then
+        local ok, module = pcall(function()
+            return require(ReplicatedStorage:WaitForChild("FetchItem"))
+        end)
+        if ok then
+            FetchItemModule = module
+        else
+            warn("[MinersHaven] failed to resolve FetchItem", module)
+        end
+    end
+    if not MoneyLibrary then
+        local ok, module = pcall(function()
+            return require(ReplicatedStorage:WaitForChild("MoneyLib"))
+        end)
+        if ok then
+            MoneyLibrary = module
+        else
+            warn("[MinersHaven] failed to resolve MoneyLib", module)
+        end
+    end
+end
+
+local function refreshCharacter()
+    local character = LocalPlayer.Character or LocalPlayer.CharacterAdded:Wait()
+    humanoid = character:WaitForChild("Humanoid")
+    humanoidRoot = character:WaitForChild("HumanoidRootPart")
+end
+
+refreshCharacter()
+LocalPlayer.CharacterAdded:Connect(refreshCharacter)
+
+---------------------------------------------------------------------
+-- Utilities
+---------------------------------------------------------------------
+
+local function getItem(name)
+    ensureLibraries()
+    local success, item = pcall(function()
+        return ReplicatedStorage.Items[name]
+    end)
+    if not success then
+        warn("[MinersHaven] missing item", name, item)
+        return nil
+    end
+    return item
+end
+
+local function ShopItems()
+    ensureLibraries()
+    for _, candidate in ipairs(getgc(true)) do
+        if type(candidate) == "table" and rawget(candidate, "Miscs") then
+            return candidate["All"]
+        end
+    end
+    return {}
+end
+
+local function HasItem(name, returnCount)
+    local owned = ReplicatedStorage:WaitForChild("HasItem"):InvokeServer(name) or 0
+    if returnCount then
+        return owned
+    end
+    return owned > 0
+end
+
+local function IsShopItem(itemId)
+    for _, entry in ipairs(ShopItems()) do
+        if tonumber(entry.ItemId.Value) == tonumber(itemId) then
+            return true
+        end
+    end
+    return false
+end
+
+local minerHavenBoxIncludePatterns = {
+    "Box",
+    "Gift",
+    "Crate",
+}
+
+local minerHavenBoxExcludePatterns = {
+    "overlay",
+    "inside",
+    "Lava",
+    "Mine",
+    "Handle",
+    "Upgrade",
+    "Conv",
+    "Mesh",
+    "Terrain",
+}
+
+local function cleanupTouchedMHBoxes()
+    for box, timestamp in pairs(touchedMHBoxes) do
+        if not box or not box.Parent then
+            touchedMHBoxes[box] = nil
+        elseif timestamp + 30 < os.clock() then
+            touchedMHBoxes[box] = nil
+        end
+    end
+end
+
+local function getMinerHavenBoxKey(part)
+    if part.Parent and part.Parent:IsA("Model") then
+        return part.Parent
+    end
+    return part
+end
+
+local function isMinerHavenBox(part)
+    if not part or not part:IsA("BasePart") then
+        return false
+    end
+    for _, include in ipairs(minerHavenBoxIncludePatterns) do
+        if part.Name:match(include) then
+            for _, exclude in ipairs(minerHavenBoxExcludePatterns) do
+                if part.Name:match(exclude) then
+                    return false
+                end
+            end
+            return true
+        end
+    end
+    return false
+end
+
+local function getClosestPart(instances)
+    if not humanoidRoot then
+        return nil
+    end
+    local closest
+    local closestDistance = math.huge
+    for _, instance in ipairs(instances) do
+        local candidate = instance
+        if candidate:IsA("Model") then
+            candidate = candidate.PrimaryPart or candidate:FindFirstChildWhichIsA("BasePart")
+        end
+        if candidate and candidate:IsA("BasePart") then
+            local distance = (candidate.Position - humanoidRoot.Position).Magnitude
+            if distance < closestDistance then
+                closestDistance = distance
+                closest = candidate
+            end
+        end
+    end
+    return closest
+end
+
+local function moveTo(position)
+    if not humanoid then
+        return false
+    end
+    if not LegitPathing then
+        humanoidRoot.CFrame = CFrame.new(position)
+        return true
+    end
+    if pathfindingBusy then
+        return false
+    end
+    pathfindingBusy = true
+    local path = PathfindingService:CreatePath({
+        AgentCanJump = true,
+        AgentHeight = humanoid.HipHeight,
+        AgentRadius = humanoid.HipHeight / 2,
+    })
+    path:ComputeAsync(humanoidRoot.Position, position)
+    if path.Status ~= Enum.PathStatus.Success then
+        pathfindingBusy = false
+        return false
+    end
+    for _, waypoint in ipairs(path:GetWaypoints()) do
+        humanoid:MoveTo(waypoint.Position)
+        if waypoint.Action == Enum.PathWaypointAction.Jump then
+            humanoid.Jump = true
+        end
+        humanoid.MoveToFinished:Wait()
+    end
+    pathfindingBusy = false
+    return true
+end
+
+MinersHaven.Modules.Utilities.getItem = getItem
+MinersHaven.Modules.Utilities.ShopItems = ShopItems
+MinersHaven.Modules.Utilities.HasItem = HasItem
+MinersHaven.Modules.Utilities.IsShopItem = IsShopItem
+MinersHaven.Modules.Utilities.getMinerHavenBoxKey = getMinerHavenBoxKey
+MinersHaven.Modules.Utilities.isMinerHavenBox = isMinerHavenBox
+MinersHaven.Modules.Utilities.getClosestPart = getClosestPart
+MinersHaven.Modules.Utilities.moveTo = moveTo
+MinersHaven.Modules.Pathing.moveTo = moveTo
+
+---------------------------------------------------------------------
+-- Farming helpers
+---------------------------------------------------------------------
+
+local collectBoxesTask
+local collectCloversTask
+local openBoxesTask
+local rebirthTask
+
+local function collectBoxesLoop()
+    while MinersHaven.State.collectBoxes do
+        cleanupTouchedMHBoxes()
+        local character = LocalPlayer.Character or LocalPlayer.CharacterAdded:Wait()
+        local rootPart = character:WaitForChild("HumanoidRootPart")
+        local candidateBoxes = {}
+        for _, descendant in ipairs(workspace:GetDescendants()) do
+            if isMinerHavenBox(descendant) then
+                local key = getMinerHavenBoxKey(descendant)
+                if not touchedMHBoxes[key] then
+                    table.insert(candidateBoxes, {part = descendant, key = key})
+                end
+            end
+        end
+        table.sort(candidateBoxes, function(a, b)
+            return (a.part.Position - rootPart.Position).Magnitude <
+                (b.part.Position - rootPart.Position).Magnitude
+        end)
+        for _, entry in ipairs(candidateBoxes) do
+            if not MinersHaven.State.collectBoxes then
+                break
+            end
+            if entry.part and entry.part.Parent then
+                local before = rootPart.CFrame
+                moveTo(entry.part.Position)
+                touchedMHBoxes[entry.key] = os.clock()
+                if not LegitPathing then
+                    task.wait(0.1)
+                    rootPart.CFrame = before
+                end
+            end
+        end
+        task.wait(0.35)
+    end
+    collectBoxesTask = nil
+end
+
+local function collectCloversLoop()
+    while MinersHaven.State.collectClovers do
+        local clovers = workspace:FindFirstChild("Clovers")
+        if not clovers then
+            task.wait(1)
+            continue
+        end
+        local target = getClosestPart(clovers:GetChildren())
+        if target then
+            local before = humanoidRoot.CFrame
+            moveTo(target.Position)
+            task.wait(1.2)
+            humanoidRoot.CFrame = before
+        else
+            task.wait(1)
+        end
+    end
+    collectCloversTask = nil
+end
+
+local function openBoxesLoop()
+    while MinersHaven.State.autoOpenBoxes do
+        for _, crate in ipairs(LocalPlayer.Crates:GetChildren()) do
+            ReplicatedStorage.MysteryBox:InvokeServer(crate.Name)
+            task.wait(0.05)
+        end
+        task.wait(0.5)
+    end
+    openBoxesTask = nil
+end
+
+local function destroyAll()
+    ReplicatedStorage.DestroyAll:InvokeServer()
+    task.wait(0.7)
+end
+
+local function autoRebirthLoop()
+    ensureLibraries()
+    while MinersHaven.State.autoRebirth do
+        local rebirths = LocalPlayer:FindFirstChild("Rebirths")
+        if rebirths and MoneyLibrary then
+            local nextCost = MoneyLibrary and MoneyLibrary.CalculateRebirthCost(rebirths.Value + 1)
+            if nextCost then
+                ReplicatedStorage.Rebirth:InvokeServer()
+            end
+        end
+        task.wait(5)
+    end
+    rebirthTask = nil
+end
+
+local function startCollectBoxes(value)
+    MinersHaven.State.collectBoxes = value
+    if value and not collectBoxesTask then
+        collectBoxesTask = task.spawn(collectBoxesLoop)
+    end
+end
+
+local function startCollectClovers(value)
+    MinersHaven.State.collectClovers = value
+    if value and not collectCloversTask then
+        collectCloversTask = task.spawn(collectCloversLoop)
+    end
+end
+
+local function startOpenBoxes(value)
+    MinersHaven.State.autoOpenBoxes = value
+    if value and not openBoxesTask then
+        openBoxesTask = task.spawn(openBoxesLoop)
+    end
+end
+
+local function startAutoRebirth(value)
+    MinersHaven.State.autoRebirth = value
+    if value and not rebirthTask then
+        rebirthTask = task.spawn(autoRebirthLoop)
+    end
+end
+
+MinersHaven.Modules.Farming.collectBoxes = startCollectBoxes
+MinersHaven.Modules.Farming.collectClovers = startCollectClovers
+MinersHaven.Modules.Farming.autoOpenBoxes = startOpenBoxes
+MinersHaven.Modules.Farming.destroyAll = destroyAll
+MinersHaven.Modules.Farming.autoRebirth = startAutoRebirth
+
+---------------------------------------------------------------------
+-- Inventory helpers
+---------------------------------------------------------------------
+
+local catalysts = {
+    ["Catalyst of Thunder"] = {
+        name = "Draedon's Gauntlet",
+        items = {
+            "True Book of Knowledge",
+            "Tempest Refiner",
+            "Lightningbolt Predictor",
+            "Azure Purifier",
+        },
+    },
+}
+
+local function hasCatalyst(name)
+    return HasItem(name)
+end
+
+MinersHaven.Modules.Inventory.catalysts = catalysts
+MinersHaven.Modules.Inventory.hasCatalyst = hasCatalyst
+
+---------------------------------------------------------------------
+-- UI
+---------------------------------------------------------------------
+
+local function buildVenyxUI()
+    local venyx = loadstring(game:HttpGet("https://raw.githubusercontent.com/Stefanuk12/Venyx-UI-Library/main/source2.lua"))()
+    local ui = venyx.new({title = "Revamp - Miner's Haven"})
+
+    local minersPage = ui:addPage({title = "Miner's Haven"})
+    local boxesSection = minersPage:addSection({title = "Boxes"})
+
+    boxesSection:addToggle({
+        title = "Collect Boxes",
+        callback = startCollectBoxes,
+    })
+
+    boxesSection:addToggle({
+        title = "Auto open Boxes",
+        callback = startOpenBoxes,
+    })
+
+    boxesSection:addToggle({
+        title = "Collect Clovers",
+        callback = startCollectClovers,
+    })
+
+    boxesSection:addToggle({
+        title = "Legit Pathing?",
+        callback = function(value)
+            LegitPathing = value
+            MinersHaven.State.legitPathing = value
+        end,
+    })
+
+    boxesSection:addButton({
+        title = "Load AutoRebirth",
+        callback = function()
+            startAutoRebirth(true)
+        end,
+    })
+
+    local themePage = ui:addPage({title = "Theme"})
+    local colorsSection = themePage:addSection({title = "Colors"})
+    for theme, color in pairs({
+        Background = Color3.fromRGB(24, 24, 24),
+        Glow = Color3.fromRGB(0, 0, 0),
+        Accent = Color3.fromRGB(10, 10, 10),
+        LightContrast = Color3.fromRGB(20, 20, 20),
+        DarkContrast = Color3.fromRGB(14, 14, 14),
+        TextColor = Color3.fromRGB(255, 255, 255),
+    }) do
+        colorsSection:addColorPicker({
+            title = theme,
+            default = color,
+            callback = function(newColor)
+                venyx:setTheme(theme, newColor)
+            end,
+        })
+    end
+
+    MinersHaven.UI.instances.library = venyx
+    MinersHaven.UI.instances.ui = ui
+    return ui
+end
+
+local function buildAutoRebirthWindow()
+    local library = loadstring(game:HttpGet("https://raw.githubusercontent.com/bloodball/-back-ups-for-libs/main/wally%20ui%20library"))()
+    local window = library:CreateWindow("Miner's Haven")
+    local farmSection = window:CreateFolder("Farm")
+
+    farmSection:Toggle("Rebirth Farm", function(value)
+        startAutoRebirth(value)
+    end)
+
+    farmSection:Toggle("Auto Rebirth", function(value)
+        startAutoRebirth(value)
+    end)
+
+    farmSection:Box("Time first layout", function(value)
+        MinersHaven.Data.LayoutCosts.first = value
+    end)
+
+    farmSection:Box("Time second layout", function(value)
+        MinersHaven.Data.LayoutCosts.second = value
+    end)
+
+    MinersHaven.UI.instances.rebirthLibrary = library
+    MinersHaven.UI.instances.rebirthWindow = window
+    return window
+end
+
+---------------------------------------------------------------------
+-- Initialisation
+---------------------------------------------------------------------
+
+function MinersHaven.init()
+    if game.PlaceId ~= MinersHaven.PlaceId then
+        return
+    end
+    ensureLibraries()
+    buildVenyxUI():SelectPage(1)
+    buildAutoRebirthWindow()
+end
+
+return MinersHaven
+

--- a/3101667897.lua
+++ b/3101667897.lua
@@ -1,0 +1,451 @@
+--[[
+    Legend of Speed automation split.  Provides orb farming helpers extracted
+    from the original RevampLua monolith while keeping the public API
+    intentionally small while restoring the historical Auto Race toggle.
+]]
+
+local Players = game:GetService("Players")
+local RunService = game:GetService("RunService")
+local PathfindingService = game:GetService("PathfindingService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local LocalPlayer = Players.LocalPlayer
+
+local LegendOfSpeed = {
+    PlaceId = 3101667897,
+    Services = {
+        Players = Players,
+        RunService = RunService,
+        PathfindingService = PathfindingService,
+        ReplicatedStorage = ReplicatedStorage,
+    },
+    Data = {
+        OrbSpawns = {},
+        RebirthRemote = nil,
+        RebirthRequirement = nil,
+        RacePads = {},
+    },
+    State = {
+        autoOrbs = false,
+        autoRebirth = false,
+        autoRace = false,
+    },
+    Modules = {
+        Utilities = {},
+        Pathing = {},
+        Farming = {},
+        Combat = {},
+        Logging = {},
+    },
+    UI = {
+        instances = {},
+    },
+}
+
+---------------------------------------------------------------------
+-- Utility helpers
+---------------------------------------------------------------------
+
+local humanoidRoot
+local rebirthWarnedMissing = false
+local rebirthWarnedFailure = false
+
+local function refreshCharacter()
+    local character = LocalPlayer.Character or LocalPlayer.CharacterAdded:Wait()
+    humanoidRoot = character:WaitForChild("HumanoidRootPart")
+end
+
+refreshCharacter()
+LocalPlayer.CharacterAdded:Connect(refreshCharacter)
+
+local function orbFolder()
+    local folder = workspace:FindFirstChild("orbFolder")
+    if not folder then
+        return nil
+    end
+    return folder:FindFirstChild("City") or folder
+end
+
+local function collectOrb(orbPart)
+    if not orbPart or not orbPart:IsA("BasePart") then
+        return
+    end
+    local before = humanoidRoot.CFrame
+    humanoidRoot.CFrame = orbPart.CFrame
+    task.wait(0.05)
+    humanoidRoot.CFrame = before
+end
+
+local function collectAllOrbs()
+    local container = orbFolder()
+    if not container then
+        warn("[LegendOfSpeed] orb folder not found")
+        return
+    end
+    for _, child in ipairs(container:GetChildren()) do
+        if child:IsA("Model") then
+            for _, part in ipairs(child:GetChildren()) do
+                if part:IsA("BasePart") and not part.Name:match("Union") then
+                    collectOrb(part)
+                end
+            end
+        elseif child:IsA("BasePart") then
+            collectOrb(child)
+        end
+    end
+end
+
+LegendOfSpeed.Modules.Utilities.orbFolder = orbFolder
+LegendOfSpeed.Modules.Utilities.collectOrb = collectOrb
+LegendOfSpeed.Modules.Utilities.collectAllOrbs = collectAllOrbs
+
+local function isRacePad(instance)
+    if not instance or not instance:IsA("BasePart") then
+        return false
+    end
+    local name = instance.Name:lower()
+    if not name:find("race") then
+        return false
+    end
+    return name:find("pad") or name:find("join") or name:find("start")
+end
+
+local function rebuildRacePads()
+    local pads = {}
+    local seen = {}
+    local candidates = {
+        workspace:FindFirstChild("RacePads"),
+        workspace:FindFirstChild("RaceStarts"),
+        workspace:FindFirstChild("Races"),
+    }
+    for _, container in ipairs(candidates) do
+        if container then
+            for _, descendant in ipairs(container:GetDescendants()) do
+                if isRacePad(descendant) and not seen[descendant] then
+                    table.insert(pads, descendant)
+                    seen[descendant] = true
+                end
+            end
+        end
+    end
+    if #pads == 0 then
+        for _, descendant in ipairs(workspace:GetDescendants()) do
+            if isRacePad(descendant) and not seen[descendant] then
+                table.insert(pads, descendant)
+                seen[descendant] = true
+            end
+        end
+    end
+    table.sort(pads, function(a, b)
+        return a.Name < b.Name
+    end)
+    LegendOfSpeed.Data.RacePads = pads
+    return pads
+end
+
+local function getRacePads()
+    if #LegendOfSpeed.Data.RacePads == 0 then
+        return rebuildRacePads()
+    end
+    local pads = {}
+    for _, pad in ipairs(LegendOfSpeed.Data.RacePads) do
+        if pad and pad:IsDescendantOf(workspace) then
+            table.insert(pads, pad)
+        end
+    end
+    if #pads == 0 then
+        return rebuildRacePads()
+    end
+    LegendOfSpeed.Data.RacePads = pads
+    return pads
+end
+
+LegendOfSpeed.Modules.Utilities.isRacePad = isRacePad
+LegendOfSpeed.Modules.Utilities.getRacePads = getRacePads
+LegendOfSpeed.Modules.Utilities.rebuildRacePads = rebuildRacePads
+
+---------------------------------------------------------------------
+-- Farming helpers
+---------------------------------------------------------------------
+
+local autoOrbTask
+local autoRebirthTask
+local autoRaceTask
+
+local function autoOrbsLoop()
+    while LegendOfSpeed.State.autoOrbs do
+        local success, err = pcall(collectAllOrbs)
+        if not success then
+            warn("[LegendOfSpeed] auto orb loop", err)
+            task.wait(1)
+        else
+            task.wait(0.3)
+        end
+    end
+    autoOrbTask = nil
+end
+
+local function startAutoOrbs(value)
+    LegendOfSpeed.State.autoOrbs = value
+    if value and not autoOrbTask then
+        autoOrbTask = task.spawn(autoOrbsLoop)
+    elseif not value and autoOrbTask then
+        while autoOrbTask do
+            task.wait()
+        end
+    end
+end
+
+local function getRebirthRequirement()
+    local requirement = LegendOfSpeed.Data.RebirthRequirement
+    if requirement and requirement > 0 then
+        return requirement
+    end
+    local containers = {
+        LocalPlayer:FindFirstChild("dataFolder"),
+        LocalPlayer:FindFirstChild("DataFolder"),
+        LocalPlayer:FindFirstChild("leaderstats"),
+    }
+    for _, folder in ipairs(containers) do
+        if folder then
+            local value = folder:FindFirstChild("RebirthRequirement") or folder:FindFirstChild("rebirthRequirement")
+            if value and typeof(value.Value) == "number" then
+                LegendOfSpeed.Data.RebirthRequirement = value.Value
+                return value.Value
+            end
+        end
+    end
+    return requirement
+end
+
+local function resolveRebirthRemote()
+    local cached = LegendOfSpeed.Data.RebirthRemote
+    if cached and cached.Parent then
+        return cached
+    end
+    for _, descendant in ipairs(ReplicatedStorage:GetDescendants()) do
+        if descendant:IsA("RemoteEvent") or descendant:IsA("RemoteFunction") then
+            if descendant.Name:lower():find("rebirth") then
+                LegendOfSpeed.Data.RebirthRemote = descendant
+                return descendant
+            end
+        end
+    end
+    LegendOfSpeed.Data.RebirthRemote = nil
+    return nil
+end
+
+local function tryRebirth()
+    local remote = resolveRebirthRemote()
+    if not remote then
+        if not rebirthWarnedMissing then
+            rebirthWarnedMissing = true
+            warn("[LegendOfSpeed] Unable to locate a rebirth remote. Auto rebirth will retry.")
+        end
+        return
+    end
+    rebirthWarnedMissing = false
+    local success, err
+    if remote:IsA("RemoteFunction") then
+        success, err = pcall(remote.InvokeServer, remote)
+    else
+        success, err = pcall(remote.FireServer, remote)
+    end
+    if not success and not rebirthWarnedFailure then
+        rebirthWarnedFailure = true
+        warn("[LegendOfSpeed] Rebirth remote rejected call:", err)
+    elseif success then
+        rebirthWarnedFailure = false
+    end
+end
+
+local function autoRebirthLoop()
+    while LegendOfSpeed.State.autoRebirth do
+        local stats = LocalPlayer:FindFirstChild("leaderstats")
+        local steps = stats and stats:FindFirstChild("Steps")
+        local requirement = getRebirthRequirement()
+        if steps and requirement and steps.Value >= requirement then
+            tryRebirth()
+        else
+            tryRebirth()
+        end
+        task.wait(5)
+    end
+    autoRebirthTask = nil
+end
+
+local function setAutoRebirth(value)
+    LegendOfSpeed.State.autoRebirth = value
+    if value and not autoRebirthTask then
+        autoRebirthTask = task.spawn(autoRebirthLoop)
+    elseif not value and autoRebirthTask then
+        while autoRebirthTask do
+            task.wait()
+        end
+    end
+end
+
+local function joinRacePad(pad)
+    if not pad or not pad:IsA("BasePart") then
+        return
+    end
+    local character = LocalPlayer.Character or LocalPlayer.CharacterAdded:Wait()
+    local humanoid = character:FindFirstChildOfClass("Humanoid")
+    if not humanoid or not humanoidRoot then
+        return
+    end
+    local original = humanoidRoot.CFrame
+    local originalState = humanoid:GetState()
+    humanoid:ChangeState(Enum.HumanoidStateType.Physics)
+    humanoidRoot.CFrame = pad.CFrame + Vector3.new(0, pad.Size.Y / 2 + 2, 0)
+    task.wait(0.25)
+    humanoidRoot.CFrame = original
+    humanoid:ChangeState(originalState)
+end
+
+LegendOfSpeed.Modules.Utilities.joinRacePad = joinRacePad
+
+local function autoRaceLoop()
+    local index = 1
+    while LegendOfSpeed.State.autoRace do
+        local pads = getRacePads()
+        if #pads == 0 then
+            task.wait(5)
+        else
+            if index > #pads then
+                index = 1
+            end
+            local pad = pads[index]
+            index = index + 1
+            local success, err = pcall(joinRacePad, pad)
+            if not success then
+                warn("[LegendOfSpeed] auto race join failed", err)
+            end
+            task.wait(2.5)
+        end
+    end
+    autoRaceTask = nil
+end
+
+local function setAutoRace(value)
+    LegendOfSpeed.State.autoRace = value
+    if value and not autoRaceTask then
+        autoRaceTask = task.spawn(autoRaceLoop)
+    elseif not value and autoRaceTask then
+        while autoRaceTask do
+            task.wait()
+        end
+    end
+end
+
+LegendOfSpeed.Modules.Farming.collectAllOrbs = collectAllOrbs
+LegendOfSpeed.Modules.Farming.startAutoOrbs = startAutoOrbs
+LegendOfSpeed.Modules.Farming.setAutoRebirth = setAutoRebirth
+LegendOfSpeed.Modules.Farming.setAutoRace = setAutoRace
+LegendOfSpeed.Modules.Farming.joinRacePad = joinRacePad
+
+---------------------------------------------------------------------
+-- Pathing helpers
+---------------------------------------------------------------------
+
+local function moveTo(position)
+    local character = LocalPlayer.Character or LocalPlayer.CharacterAdded:Wait()
+    local humanoid = character:WaitForChild("Humanoid")
+    local path = PathfindingService:CreatePath({AgentCanJump = true})
+    path:ComputeAsync(humanoidRoot.Position, position)
+    if path.Status ~= Enum.PathStatus.Success then
+        humanoidRoot.CFrame = CFrame.new(position)
+        return
+    end
+    for _, waypoint in ipairs(path:GetWaypoints()) do
+        humanoid:MoveTo(waypoint.Position)
+        if waypoint.Action == Enum.PathWaypointAction.Jump then
+            humanoid.Jump = true
+        end
+        humanoid.MoveToFinished:Wait()
+    end
+end
+
+LegendOfSpeed.Modules.Pathing.moveTo = moveTo
+
+---------------------------------------------------------------------
+-- UI
+---------------------------------------------------------------------
+
+local function buildUI()
+    local venyx = loadstring(game:HttpGet("https://raw.githubusercontent.com/Stefanuk12/Venyx-UI-Library/main/source2.lua"))()
+    local ui = venyx.new({title = "Revamp - Legend of Speed"})
+
+    local losPage = ui:addPage({title = "LoS"})
+    local orbsSection = losPage:addSection({title = "Orbs"})
+
+    orbsSection:addButton({
+        title = "Get all",
+        callback = collectAllOrbs,
+    })
+
+    orbsSection:addToggle({
+        title = "Auto Orbs",
+        toggled = LegendOfSpeed.State.autoOrbs,
+        callback = startAutoOrbs,
+    })
+
+    local progressionSection = losPage:addSection({title = "Progression"})
+
+    progressionSection:addToggle({
+        title = "Auto Rebirth",
+        toggled = LegendOfSpeed.State.autoRebirth,
+        callback = setAutoRebirth,
+    })
+
+    local racesSection = losPage:addSection({title = "Races"})
+
+    racesSection:addButton({
+        title = "Refresh pads",
+        callback = rebuildRacePads,
+    })
+
+    racesSection:addToggle({
+        title = "Auto Race",
+        toggled = LegendOfSpeed.State.autoRace,
+        callback = setAutoRace,
+    })
+
+    local themePage = ui:addPage({title = "Theme"})
+    local colorsSection = themePage:addSection({title = "Colors"})
+    for theme, color in pairs({
+        Background = Color3.fromRGB(24, 24, 24),
+        Glow = Color3.fromRGB(0, 0, 0),
+        Accent = Color3.fromRGB(10, 10, 10),
+        LightContrast = Color3.fromRGB(20, 20, 20),
+        DarkContrast = Color3.fromRGB(14, 14, 14),
+        TextColor = Color3.fromRGB(255, 255, 255),
+    }) do
+        colorsSection:addColorPicker({
+            title = theme,
+            default = color,
+            callback = function(newColor)
+                venyx:setTheme(theme, newColor)
+            end,
+        })
+    end
+
+    LegendOfSpeed.UI.instances.library = venyx
+    LegendOfSpeed.UI.instances.ui = ui
+    return ui
+end
+
+---------------------------------------------------------------------
+-- Initialisation
+---------------------------------------------------------------------
+
+function LegendOfSpeed.init()
+    if game.PlaceId ~= LegendOfSpeed.PlaceId then
+        return
+    end
+    rebuildRacePads()
+    buildUI():SelectPage(1)
+end
+
+return LegendOfSpeed
+

--- a/5712833750.lua
+++ b/5712833750.lua
@@ -1,0 +1,1590 @@
+--[[
+    Animal Simulator automation module extracted from RevampLua.lua.
+
+    The goal of this split file is to retain only the functionality that is
+    required when the loader detects we are inside Animal Simulator
+    (PlaceId 5712833750).  All helpers that were previously exposed through
+    the `Revamp` table are reorganised below under the `AnimalSim` namespace.
+
+    The implementation is intentionally faithful to the original logic so the
+    in‑game behaviour remains unchanged while still keeping the local count of
+    this file well under Roblox's limit.  Shared helpers that are reused by the
+    other games will be duplicated in their respective split files.
+]]
+
+local Players = game:GetService("Players")
+local RunService = game:GetService("RunService")
+local PathfindingService = game:GetService("PathfindingService")
+local UserInputService = game:GetService("UserInputService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local LocalPlayer = Players.LocalPlayer
+
+local AnimalSim = {
+    PlaceId = 5712833750,
+    Services = {
+        Players = Players,
+        RunService = RunService,
+        PathfindingService = PathfindingService,
+        UserInputService = UserInputService,
+        ReplicatedStorage = ReplicatedStorage,
+    },
+    Data = {
+        SafeZones = {},
+        Teleporters = {},
+        prefixes = {},
+        Zones = {},
+    },
+    State = {
+        autoPVP = false,
+        killAura = false,
+        autoJump = false,
+        autoEat = false,
+        autoFight = false,
+        autoZone = false,
+        autoFlightChase = false,
+        autoFireball = false,
+        followTarget = false,
+        followDistance = 10,
+        selectedPlayer = nil,
+        legitMode = true,
+        autoSelectTarget = false,
+    },
+    Modules = {
+        Utilities = {},
+        Pathing = {},
+        Combat = {},
+        Farming = {},
+        Inventory = {},
+        Logging = {},
+    },
+    UI = {
+        instances = {},
+    },
+}
+
+---------------------------------------------------------------------
+-- Data bootstrap
+---------------------------------------------------------------------
+
+local prefixes = loadstring(game:HttpGet(
+    "https://raw.githubusercontent.com/gaston1799/HostedFiles/refs/heads/main/table.lua"
+))()
+
+AnimalSim.Data.prefixes = prefixes
+
+local SAFE_ZONE_POLYGON = {
+    Vector2.new(-47.553, 585.940),
+    Vector2.new(-277.322, 672.467),
+    Vector2.new(-344.602, 483.516),
+    Vector2.new(-114.346, 401.818),
+}
+
+AnimalSim.Data.SafeZones.Main = {polygon = SAFE_ZONE_POLYGON}
+
+Players.PlayerRemoving:Connect(function(player)
+    if AnimalSim.State.selectedPlayer == player then
+        AnimalSim.State.selectedPlayer = nil
+    end
+end)
+
+local MANTIS_TELEPORT_ENTRY = Vector3.new(200.921, 708.134, -16601.699)
+local MANTIS_RETURN_POSITION = Vector3.new(67.475, 641.687, 476.413)
+local MANTIS_INSIDE_POSITION = Vector3.new(283.289, 660.560, -16678.158)
+
+AnimalSim.Data.Teleporters.MantisEntry = {
+    entry = MANTIS_TELEPORT_ENTRY,
+    destination = Vector3.new(591.384, 647.570, -16412.795),
+    waitTime = 0.75,
+}
+
+AnimalSim.Data.Teleporters.MantisPortal = {
+    entry = MANTIS_TELEPORT_ENTRY,
+    destination = MANTIS_INSIDE_POSITION,
+    waitTime = 0.8,
+    arrivalRadius = 30,
+    penalty = 0,
+    minDirectDistance = 0,
+    teleporterName = "MantisPortal",
+    insidePosition = MANTIS_INSIDE_POSITION,
+    returnPosition = MANTIS_RETURN_POSITION,
+}
+
+---------------------------------------------------------------------
+-- Utility helpers
+---------------------------------------------------------------------
+
+local DAMAGE_REMOTE = ReplicatedStorage:FindFirstChild("jdskhfsIIIllliiIIIdchgdIiIIIlIlIli", true)
+local TELEPORTERS = {}
+
+local humanoid
+local humanoidRoot
+local prefixesBySuffix = prefixes
+local deathPose
+local justDied = false
+local incDMG = 100
+local autoEatTask
+local autoEatEnabled = false
+local autoFireballTask
+local autoFireballEnabled = false
+local autoZoneTask
+local autoZoneEnabled = false
+local autoPVPTask
+local autoPVPEnabled = false
+local autoFlightChaseTask
+local autoFlightChaseEnabled = false
+local autoZoneBaseCF
+local autoZoneCancelToken = 0
+local followTaskRunning = false
+local autoJumpEnabled = false
+local autoJumpConnection
+local autoJumpCharacterConnection
+local mantisTeleportActive = false
+local mantisTeleportReturnCF
+
+local AUTO_PVP_POLL_RATE = 0.35
+local AUTO_ZONE_POLL_RATE = 0.6
+
+local function teamCheck(name)
+    if not name then
+        return false
+    end
+    local playerTeam
+    for _, team in ipairs(workspace.Teams:GetChildren()) do
+        if team:FindFirstChild(LocalPlayer.Name) then
+            playerTeam = team
+            break
+        end
+    end
+    if not playerTeam then
+        return false
+    end
+    return playerTeam:FindFirstChild(name) ~= nil
+end
+
+local function myTeam(name)
+    name = name or LocalPlayer.Name
+    local foundLeader
+    local foundTeam
+    for _, team in ipairs(workspace.Teams:GetChildren()) do
+        local teamLeader
+        local hasMember = false
+        for _, member in ipairs(team:GetChildren()) do
+            local ok, value = pcall(function()
+                return member.Value
+            end)
+            if member.Name == "leader" and ok then
+                teamLeader = typeof(value) == "Instance" and value.Name or value
+            end
+            if ok and (value == name or (typeof(value) == "Instance" and value.Name == name)) then
+                hasMember = true
+            end
+        end
+        if hasMember then
+            foundLeader = teamLeader
+            foundTeam = team.Name
+            break
+        end
+    end
+    return {foundLeader, foundTeam}
+end
+
+local function findClosestPlayer()
+    local localCharacter = LocalPlayer.Character
+    if not localCharacter then
+        return nil
+    end
+    local localRoot = localCharacter.PrimaryPart
+    if not localRoot then
+        return nil
+    end
+    local closest
+    local closestDistance = math.huge
+    for _, player in ipairs(Players:GetPlayers()) do
+        if player ~= LocalPlayer then
+            local character = player.Character
+            local humanoidInstance = character and character:FindFirstChildOfClass("Humanoid")
+            local root = character and character.PrimaryPart
+            if humanoidInstance and humanoidInstance.Health > 0 and root and not teamCheck(player.Name) then
+                local distance = (localRoot.Position - root.Position).Magnitude
+                if distance < closestDistance then
+                    closestDistance = distance
+                    closest = player
+                end
+            end
+        end
+    end
+    return closest
+end
+
+local function findClosestEnemy()
+    local localCharacter = LocalPlayer.Character
+    if not localCharacter then
+        return nil
+    end
+    local localRoot = localCharacter.PrimaryPart
+    if not localRoot then
+        return nil
+    end
+    local myInfo = myTeam()
+    local myLeader = myInfo[1]
+    local myTeamName = myInfo[2]
+    local closest
+    local closestDistance = math.huge
+    for _, player in ipairs(Players:GetPlayers()) do
+        if player ~= LocalPlayer then
+            local character = player.Character
+            local humanoidInstance = character and character:FindFirstChildOfClass("Humanoid")
+            local root = character and character:FindFirstChild("HumanoidRootPart")
+            if humanoidInstance and humanoidInstance.Health > 0 and root then
+                local otherInfo = {}
+                local ok, result = pcall(myTeam, character and character.Name or player.Name)
+                if ok then
+                    otherInfo = result or {}
+                end
+                local sameLeader = myLeader ~= nil and otherInfo[1] == myLeader
+                local sameTeam = myTeamName ~= nil and otherInfo[2] == myTeamName
+                if not sameLeader and not sameTeam then
+                    local distance = (root.Position - localRoot.Position).Magnitude
+                    if distance < closestDistance then
+                        closestDistance = distance
+                        closest = player
+                    end
+                end
+            end
+        end
+    end
+    return closest
+end
+
+local function PredictPlayerPosition(player, deltaTime)
+    local character = player and player.Character
+    if not character then
+        return nil
+    end
+    local root = character:FindFirstChild("HumanoidRootPart")
+    if not root then
+        return nil
+    end
+    deltaTime = deltaTime or 0.2
+    local velocity = root.AssemblyLinearVelocity or root.Velocity or Vector3.zero
+    return root.Position + velocity * deltaTime
+end
+
+local function teleportInFrontOfPlayer(targetPlayerName)
+    local targetPlayer = Players:FindFirstChild(targetPlayerName)
+    if not targetPlayer then
+        return
+    end
+    local targetCharacter = targetPlayer.Character
+    local targetRoot = targetCharacter and targetCharacter:FindFirstChild("HumanoidRootPart")
+    if not (targetCharacter and targetRoot) then
+        return
+    end
+    local predictedPosition = targetRoot.Position + (targetRoot.Velocity or Vector3.zero)
+    local character = LocalPlayer.Character
+    if character and character.PrimaryPart then
+        if LegitPathing then
+            defineNilLocals()
+            local humanoidInstance = humanoid
+            if humanoidInstance then
+                local ok, err = pcall(function()
+                    moveToTarget(predictedPosition, humanoidInstance, {
+                        cancelled = function()
+                            return not LegitPathing
+                        end,
+                        arrivalDistance = 6,
+                    })
+                end)
+                if not ok then
+                    warn("[AnimalSim] failed to walk in front of player", err)
+                end
+            end
+        else
+            character:SetPrimaryPartCFrame(CFrame.new(predictedPosition))
+        end
+    end
+end
+
+local function increaseByPercentage(number, percentage)
+    number = tonumber(number)
+    percentage = tonumber(percentage)
+    if not number or not percentage then
+        error("Both arguments must be valid numbers.")
+    end
+    if percentage < 0 then
+        error("Percentage should be a positive value.")
+    end
+    return number + number * (percentage / 100)
+end
+
+local function conv(cash)
+    for _, prefix in ipairs(prefixesBySuffix) do
+        if typeof(cash) == "string" and cash:match(prefix.Prefix) then
+            local numeric = tonumber(cash:split(prefix.Prefix)[1])
+            if numeric then
+                return numeric * prefix.Number
+            end
+        end
+    end
+    return tonumber(cash) or 0
+end
+
+local function comparCash(a)
+    local leaderstats = LocalPlayer:FindFirstChild("leaderstats")
+    local cashValue = leaderstats and leaderstats:FindFirstChild("Cash")
+    local ownCash = cashValue and tonumber(string.split(cashValue.Value, "$")[2]) or 0
+    return conv(a) < ownCash
+end
+
+local playersService
+local selfPlayer
+local char
+local root
+local mouse
+local rebirthValue
+local finding = false
+local pathfindingComplete = true
+local doneMoving = true
+local LegitPathing = AnimalSim.State.legitMode
+
+local function waitForChar()
+    while not Players.LocalPlayer.Character do
+        task.wait()
+    end
+    return Players.LocalPlayer.Character
+end
+
+local function defineLocals()
+    waitForChar()
+    local success, result
+
+    success, result = pcall(function()
+        playersService = Players
+        selfPlayer = playersService.LocalPlayer
+    end)
+    if not success then
+        warn("Failed to resolve players service", result)
+        return
+    end
+
+    success, result = pcall(function()
+        char = selfPlayer.Character
+    end)
+    if not success then
+        warn("Failed to resolve character", result)
+        return
+    end
+
+    success, result = pcall(function()
+        humanoid = char:WaitForChild("Humanoid")
+        humanoidRoot = char:WaitForChild("HumanoidRootPart")
+    end)
+    if not success then
+        warn("Failed to resolve humanoid", result)
+        return
+    end
+
+    mouse = selfPlayer:GetMouse()
+
+    success, result = pcall(function()
+        rebirthValue = selfPlayer:FindFirstChild("Rebirths")
+    end)
+    if not success then
+        warn("Failed to resolve rebirth value", result)
+    end
+
+    pathfindingComplete = true
+    finding = false
+    doneMoving = true
+end
+
+local function defineNilLocals()
+    if not playersService then
+        playersService = Players
+    end
+    if not selfPlayer then
+        selfPlayer = playersService.LocalPlayer
+    end
+    if not char then
+        char = selfPlayer and selfPlayer.Character or waitForChar()
+    end
+    if not humanoid and char then
+        humanoid = char:FindFirstChildOfClass("Humanoid")
+    end
+    if not humanoidRoot and char then
+        humanoidRoot = char:FindFirstChild("HumanoidRootPart")
+    end
+    if not mouse and selfPlayer then
+        mouse = selfPlayer:GetMouse()
+    end
+    if not rebirthValue and selfPlayer then
+        rebirthValue = selfPlayer:FindFirstChild("Rebirths")
+    end
+end
+
+local function waitDoneMove()
+    while not doneMoving do
+        task.wait()
+    end
+    return true
+end
+
+local function getClosest(instances)
+    if not humanoidRoot then
+        return nil
+    end
+    local closestPart
+    local closestDistance = math.huge
+    for _, instance in ipairs(instances) do
+        local part = instance
+        if instance:IsA("Model") then
+            part = instance.PrimaryPart or instance:FindFirstChildWhichIsA("BasePart")
+        end
+        if part and part:IsA("BasePart") then
+            local distance = (part.Position - humanoidRoot.Position).Magnitude
+            if distance < closestDistance then
+                closestDistance = distance
+                closestPart = part
+            end
+        end
+    end
+    return closestPart, closestDistance
+end
+
+local function getPos()
+    local inSafe = {}
+    local safeZone1 = {86.3, 493.6}
+    local safeZone2 = {-3.5, 388.2}
+    local mine = myTeam() or {}
+    for _, player in ipairs(Players:GetPlayers()) do
+        local character = player.Character
+        local humanoidInstance = character and character:FindFirstChildOfClass("Humanoid")
+        local rootPart = character and character:FindFirstChild("HumanoidRootPart")
+        if not (character and humanoidInstance and rootPart) then
+            inSafe[player.Name] = true
+        else
+            local x = rootPart.Position.X
+            local z = rootPart.Position.Z
+            local ok, otherInfo = pcall(myTeam, character.Name)
+            if not ok then
+                otherInfo = {}
+            end
+            local sameTeam = mine[2] and otherInfo[2] == mine[2]
+            if safeZone1[1] > x and safeZone1[2] > z and safeZone2[1] < x and safeZone2[2] < z then
+                if (not mine[2]) or humanoidInstance.Health == 0 or sameTeam then
+                    inSafe[player.Name] = true
+                end
+            end
+        end
+    end
+    return inSafe
+end
+
+local function stayNearPlayer()
+    while AnimalSim.State.followTarget do
+        task.wait()
+        local selected = AnimalSim.State.selectedPlayer
+        local character = LocalPlayer.Character
+        if not (selected and character and humanoidRoot and selected.Character) then
+            continue
+        end
+        local targetRoot = selected.Character:FindFirstChild("HumanoidRootPart")
+        if not targetRoot then
+            continue
+        end
+        local distance = (targetRoot.Position - humanoidRoot.Position).Magnitude
+        if distance > (AnimalSim.State.followDistance or 10) then
+            humanoidRoot.CFrame = CFrame.new(targetRoot.Position - targetRoot.CFrame.LookVector * (AnimalSim.State.followDistance or 10))
+        end
+    end
+end
+
+local function runFollowLoop()
+    followTaskRunning = true
+    stayNearPlayer()
+    followTaskRunning = false
+end
+
+local function setFollowTargetEnabled(value)
+    AnimalSim.State.followTarget = value
+    AnimalSim.State.autoSelectTarget = value
+    if value then
+        if not followTaskRunning then
+            task.spawn(runFollowLoop)
+        end
+    else
+        local timeout = os.clock() + 2
+        while followTaskRunning and os.clock() < timeout do
+            task.wait()
+        end
+    end
+end
+
+local function setLegitMode(value)
+    LegitPathing = value
+    AnimalSim.State.legitMode = value
+end
+
+local function bindAutoJumpToHumanoid(humanoidInstance)
+    if autoJumpConnection then
+        autoJumpConnection:Disconnect()
+        autoJumpConnection = nil
+    end
+    if not humanoidInstance then
+        return
+    end
+    autoJumpConnection = humanoidInstance.StateChanged:Connect(function(_, newState)
+        if autoJumpEnabled and newState == Enum.HumanoidStateType.Landed then
+            task.delay(0.1, function()
+                if autoJumpEnabled and humanoidInstance.Parent then
+                    humanoidInstance.Jump = true
+                end
+            end)
+        end
+    end)
+end
+
+local function setAutoJump(value)
+    autoJumpEnabled = value
+    AnimalSim.State.autoJump = value
+    defineNilLocals()
+    local humanoidInstance = humanoid
+    if value then
+        if humanoidInstance then
+            bindAutoJumpToHumanoid(humanoidInstance)
+            humanoidInstance.Jump = true
+        end
+        if not autoJumpCharacterConnection then
+            autoJumpCharacterConnection = LocalPlayer.CharacterAdded:Connect(function(newCharacter)
+                if not autoJumpEnabled then
+                    return
+                end
+                local newHumanoid = newCharacter:WaitForChild("Humanoid")
+                bindAutoJumpToHumanoid(newHumanoid)
+                newHumanoid.Jump = true
+            end)
+        end
+    else
+        if autoJumpConnection then
+            autoJumpConnection:Disconnect()
+            autoJumpConnection = nil
+        end
+    end
+end
+
+local function setAutoFight(value)
+    AnimalSim.State.autoFight = value
+end
+
+local function isInsideSafeZone(position)
+    local polygon = AnimalSim.Data.SafeZones.Main.polygon
+    if not polygon or #polygon < 3 then
+        return false
+    end
+    local x = position.X
+    local z = position.Z
+    local inside = false
+    local j = #polygon
+    for i = 1, #polygon do
+        local pi = polygon[i]
+        local pj = polygon[j]
+        local condition = ((pi.Y > z) ~= (pj.Y > z)) and
+            (x < (pj.X - pi.X) * (z - pi.Y) / math.max(pj.Y - pi.Y, 1e-9) + pi.X)
+        if condition then
+            inside = not inside
+        end
+        j = i
+    end
+    return inside
+end
+
+local function getPathToPosition(targetPosition, humanoidInstance)
+    local startPosition = humanoidInstance.RootPart.Position
+    local path = PathfindingService:CreatePath({
+        AgentRadius = 3,
+        AgentHeight = 6,
+        AgentCanJump = true,
+        AgentCanClimb = true,
+        Costs = {
+            Water = 20,
+            Neon = math.huge,
+        },
+    })
+    path:ComputeAsync(startPosition, targetPosition)
+    return path
+end
+
+local function moveToTarget(target, humanoidInstance, options)
+    options = options or {}
+    humanoidInstance = humanoidInstance or humanoid
+    if not humanoidInstance then
+        return false
+    end
+    local targetPosition
+    if typeof(target) == "CFrame" then
+        targetPosition = target.Position
+    elseif typeof(target) == "Vector3" then
+        targetPosition = target
+    elseif typeof(target) == "Instance" and target:IsA("BasePart") then
+        targetPosition = target.Position
+    else
+        warn("Invalid moveToTarget target")
+        return false
+    end
+    local path = getPathToPosition(targetPosition, humanoidInstance)
+    if path.Status ~= Enum.PathStatus.Success then
+        return false
+    end
+    doneMoving = false
+    for _, waypoint in ipairs(path:GetWaypoints()) do
+        if options.cancelled and options.cancelled() then
+            break
+        end
+        humanoidInstance:MoveTo(waypoint.Position)
+        if waypoint.Action == Enum.PathWaypointAction.Jump then
+            humanoidInstance.Jump = true
+        end
+        humanoidInstance.MoveToFinished:Wait()
+    end
+    doneMoving = true
+    return true
+end
+
+local function waitWithCancel(duration, cancelled)
+    local deadline = os.clock() + duration
+    while os.clock() < deadline do
+        if cancelled and cancelled() then
+            return false
+        end
+        task.wait(0.05)
+    end
+    return true
+end
+
+local function registerTeleporter(name, config)
+    if typeof(name) ~= "string" then
+        return false
+    end
+    config = config or {}
+    local entry = config.entry
+    local destination = config.destination
+    if typeof(entry) == "CFrame" then
+        entry = entry.Position
+    end
+    if typeof(destination) == "CFrame" then
+        destination = destination.Position
+    end
+    if not entry or not destination then
+        warn(string.format("[AnimalSim] Teleporter '%s' missing entry or destination", name))
+        return false
+    end
+    TELEPORTERS[name] = {
+        entry = entry,
+        destination = destination,
+        waitTime = config.waitTime or 0.75,
+        arrivalRadius = config.arrivalRadius or 12,
+        penalty = config.penalty or 40,
+        enabled = config.enabled ~= false,
+        maxEntryDistance = config.maxEntryDistance,
+        minDirectDistance = config.minDirectDistance,
+        snapOnFail = config.snapOnFail ~= false,
+        cooldown = config.cooldown or 0,
+        lastUsed = 0,
+        description = config.description,
+        postDelay = config.postDelay or 0,
+        teleporterName = config.teleporterName,
+        returnPosition = config.returnPosition,
+        insidePosition = config.insidePosition,
+    }
+    return true
+end
+
+local function useTeleporter(name, humanoidInstance, options)
+    local tele = TELEPORTERS[name]
+    if not tele or not tele.enabled then
+        return false
+    end
+    humanoidInstance = humanoidInstance or humanoid
+    if not humanoidInstance then
+        return false
+    end
+    if tele.cooldown > 0 and (os.clock() - tele.lastUsed) < tele.cooldown then
+        return false
+    end
+    local cancelled = options and options.cancelled
+    if tele.maxEntryDistance then
+        local rootPart = humanoidInstance.RootPart
+        if not rootPart or (rootPart.Position - tele.entry).Magnitude > tele.maxEntryDistance then
+            return false
+        end
+    end
+    if not moveToTarget(tele.entry, humanoidInstance, {cancelled = cancelled}) then
+        return false
+    end
+    if not waitWithCancel(tele.waitTime, cancelled) then
+        return false
+    end
+    local rootPart = humanoidInstance.RootPart
+    if not rootPart then
+        return false
+    end
+    if (rootPart.Position - tele.destination).Magnitude > tele.arrivalRadius then
+        if tele.snapOnFail then
+            local ok = pcall(function()
+                rootPart.CFrame = CFrame.new(tele.destination)
+            end)
+            if not ok then
+                return false
+            end
+        else
+            return false
+        end
+    end
+    if tele.postDelay > 0 and not waitWithCancel(tele.postDelay, cancelled) then
+        return false
+    end
+    tele.lastUsed = os.clock()
+    return true
+end
+
+local function clearTeleporters()
+    table.clear(TELEPORTERS)
+end
+
+local function followDynamicTarget(targetPlayer, humanoidInstance, options)
+    options = options or {}
+    humanoidInstance = humanoidInstance or humanoid
+    if not humanoidInstance or not targetPlayer then
+        return false
+    end
+    local arrivalDistance = options.arrivalDistance or 140
+    local repathDistance = options.repathDistance or 18
+    local maxIterations = options.maxIterations or 12
+    local path = PathfindingService:CreatePath({
+        AgentRadius = humanoidInstance.HipHeight / 2,
+        AgentHeight = humanoidInstance.HipHeight,
+        AgentCanJump = true,
+        AgentJumpHeight = humanoidInstance.JumpHeight,
+        AgentMaxSlope = humanoidInstance.MaxSlopeAngle,
+        AgentMaxStepHeight = humanoidInstance.HipHeight,
+    })
+    local lastGoal
+    local iterations = 0
+    local reachedGoal = false
+    while iterations < maxIterations do
+        iterations += 1
+        if options.cancelled and options.cancelled() then
+            break
+        end
+        local targetCharacter = targetPlayer.Character
+        local targetRoot = targetCharacter and targetCharacter:FindFirstChild("HumanoidRootPart")
+        local rootPart = humanoidInstance.RootPart
+        if not (targetRoot and rootPart) then
+            break
+        end
+        local currentDistance = (targetRoot.Position - rootPart.Position).Magnitude
+        if currentDistance <= arrivalDistance then
+            reachedGoal = true
+            humanoidInstance:Move(Vector3.new())
+            break
+        end
+        local needRepath = not lastGoal or (targetRoot.Position - lastGoal).Magnitude >= repathDistance
+        if needRepath then
+            path:ComputeAsync(rootPart.Position, targetRoot.Position)
+            lastGoal = targetRoot.Position
+        end
+        if path.Status ~= Enum.PathStatus.Success then
+            task.wait(0.1)
+            continue
+        end
+        for _, waypoint in ipairs(path:GetWaypoints()) do
+            if options.cancelled and options.cancelled() then
+                break
+            end
+            humanoidInstance:MoveTo(waypoint.Position)
+            if waypoint.Action == Enum.PathWaypointAction.Jump then
+                humanoidInstance.Jump = true
+            end
+            humanoidInstance.MoveToFinished:Wait()
+            rootPart = humanoidInstance.RootPart
+            targetCharacter = targetPlayer.Character
+            targetRoot = targetCharacter and targetCharacter:FindFirstChild("HumanoidRootPart")
+            if not (targetRoot and rootPart) then
+                break
+            end
+            currentDistance = (targetRoot.Position - rootPart.Position).Magnitude
+            if currentDistance <= arrivalDistance then
+                reachedGoal = true
+                humanoidInstance:Move(Vector3.new())
+                return true
+            end
+            if (targetRoot.Position - lastGoal).Magnitude >= repathDistance then
+                break
+            end
+        end
+    end
+    humanoidInstance:Move(Vector3.new())
+    return reachedGoal
+end
+
+local function tryTeleportRoute(humanoidInstance, targetPosition, options)
+    local rootPart = humanoidInstance and humanoidInstance.RootPart
+    if not rootPart then
+        return false
+    end
+    local directDistance = (rootPart.Position - targetPosition).Magnitude
+    local best
+    local bestCost
+    local now = os.clock()
+    local margin = options and options.margin or 30
+    for name, tele in pairs(TELEPORTERS) do
+        if tele.enabled then
+            local passesMin = not tele.minDirectDistance or directDistance >= tele.minDirectDistance
+            local passesCooldown = not (tele.cooldown > 0 and (now - tele.lastUsed) < tele.cooldown)
+            if passesMin and passesCooldown then
+                local distToEntry = (tele.entry - rootPart.Position).Magnitude
+                local withinEntry = not tele.maxEntryDistance or distToEntry <= tele.maxEntryDistance
+                if withinEntry then
+                    local cost = distToEntry + tele.penalty
+                    if not best or cost + margin < bestCost then
+                        best = name
+                        bestCost = cost
+                    end
+                end
+            end
+        end
+    end
+    if not best then
+        return false
+    end
+    return useTeleporter(best, humanoidInstance, options)
+end
+
+local function fireFireballAtPosition(targetPosition)
+    local character = LocalPlayer.Character
+    if not character then
+        return false
+    end
+    local backpack = LocalPlayer:FindFirstChild("Backpack") or LocalPlayer.Backpack
+    local tool = character:FindFirstChildWhichIsA("Tool") or (backpack and backpack:FindFirstChildWhichIsA("Tool"))
+    if not tool then
+        return false
+    end
+    local remote = tool:FindFirstChildOfClass("RemoteEvent")
+    if not remote then
+        return false
+    end
+    local ok, err = pcall(remote.FireServer, remote, targetPosition)
+    if not ok then
+        warn("Failed to fire projectile", err)
+        return false
+    end
+    return true
+end
+
+local function getAutoFireballTargetPosition()
+    local selected = AnimalSim.State.selectedPlayer
+    if selected and selected.Character and selected.Character.PrimaryPart then
+        return PredictPlayerPosition(selected)
+    end
+    local closest = findClosestPlayer()
+    if closest then
+        return PredictPlayerPosition(closest)
+    end
+    if LocalPlayer.Character and LocalPlayer.Character.PrimaryPart then
+        return LocalPlayer.Character.PrimaryPart.Position + LocalPlayer.Character.PrimaryPart.CFrame.LookVector * 60
+    end
+    return nil
+end
+
+local function startAutoFireball()
+    if autoFireballEnabled then
+        return
+    end
+    autoFireballEnabled = true
+    AnimalSim.State.autoFireball = true
+    if autoFireballTask then
+        return
+    end
+    autoFireballTask = task.spawn(function()
+        while autoFireballEnabled do
+            local waitTime = 0.4
+            local ok, fired = pcall(function()
+                local targetPosition = getAutoFireballTargetPosition()
+                if not targetPosition then
+                    return false
+                end
+                return fireFireballAtPosition(targetPosition)
+            end)
+            if not ok then
+                warn("[AutoFireball]", fired)
+                waitTime = 0.8
+            elseif not fired then
+                waitTime = 0.6
+            end
+            task.wait(waitTime)
+        end
+        autoFireballTask = nil
+    end)
+end
+
+local function stopAutoFireball()
+    if not autoFireballEnabled then
+        return
+    end
+    autoFireballEnabled = false
+    AnimalSim.State.autoFireball = false
+    while autoFireballTask do
+        task.wait()
+    end
+end
+
+local function hitHumanoid(targetHumanoid)
+    if not targetHumanoid or not targetHumanoid.Parent then
+        return false
+    end
+    local ok, err = pcall(DAMAGE_REMOTE.FireServer, DAMAGE_REMOTE, targetHumanoid, 1)
+    if not ok then
+        warn("Failed to strike humanoid:", err)
+        return false
+    end
+    return true
+end
+
+local function getClosestEnemyHumanoid()
+    local enemy = findClosestEnemy()
+    local character = enemy and enemy.Character
+    local humanoidInstance = character and character:FindFirstChildOfClass("Humanoid")
+    return humanoidInstance
+end
+
+local function autoEatLoop()
+    local function getFoodTool()
+        local character = LocalPlayer.Character
+        if character then
+            local equipped = character:FindFirstChild("Food")
+            if equipped and equipped:IsA("Tool") then
+                return equipped
+            end
+        end
+        local backpack = LocalPlayer:FindFirstChild("Backpack") or LocalPlayer.Backpack
+        if backpack then
+            local tool = backpack:FindFirstChild("Food")
+            if tool and tool:IsA("Tool") then
+                return tool
+            end
+        end
+        return nil
+    end
+
+    while autoEatEnabled do
+        local tool = getFoodTool()
+        if not tool then
+            task.wait(0.5)
+            continue
+        end
+        local character = LocalPlayer.Character or LocalPlayer.CharacterAdded:Wait()
+        local humanoidInstance = character:FindFirstChildOfClass("Humanoid") or character:WaitForChild("Humanoid")
+        if humanoidInstance.Health < humanoidInstance.MaxHealth then
+            if tool.Parent == LocalPlayer.Backpack then
+                humanoidInstance:EquipTool(tool)
+                task.wait(0.1)
+            end
+            pcall(function()
+                tool:Activate()
+            end)
+        end
+        task.wait(2)
+    end
+end
+
+local function startAutoEat()
+    if autoEatEnabled then
+        return
+    end
+    autoEatEnabled = true
+    AnimalSim.State.autoEat = true
+    autoEatTask = task.spawn(autoEatLoop)
+end
+
+local function stopAutoEat()
+    if not autoEatEnabled then
+        return
+    end
+    autoEatEnabled = false
+    AnimalSim.State.autoEat = false
+    while autoEatTask do
+        task.wait()
+    end
+end
+
+local function hptp()
+    local localHumanoid = LocalPlayer.Character and LocalPlayer.Character:FindFirstChildOfClass("Humanoid")
+    if not localHumanoid then
+        return
+    end
+    local oldHealth = localHumanoid.Health
+    localHumanoid:GetPropertyChangedSignal("Health"):Connect(function()
+        if localHumanoid.Health < 1 then
+            deathPose = LocalPlayer.Character:WaitForChild("HumanoidRootPart").CFrame
+            justDied = true
+        end
+        if localHumanoid.Health < oldHealth then
+            local enemy = getClosestEnemyHumanoid()
+            if enemy then
+                hitHumanoid(enemy)
+            end
+        end
+        oldHealth = localHumanoid.Health
+    end)
+end
+
+---------------------------------------------------------------------
+-- Combat routines
+---------------------------------------------------------------------
+
+local auraTask
+local auraActive = false
+local farmTask
+local farmActive = false
+local DMGTask
+local DMGActive = false
+
+local function farmPassive()
+    while farmActive do
+        local targetHumanoid = getClosestEnemyHumanoid()
+        if targetHumanoid then
+            hitHumanoid(targetHumanoid)
+        end
+        task.wait(0.25)
+    end
+end
+
+local function startFarmLoop()
+    if farmTask then
+        return
+    end
+    farmTask = task.spawn(farmPassive)
+end
+
+local function stopFarmLoop()
+    if not farmTask then
+        return
+    end
+    farmActive = false
+    while farmTask do
+        task.wait()
+    end
+    farmTask = nil
+end
+
+local function setFarmActive(value)
+    if farmActive == value then
+        return
+    end
+    farmActive = value
+    AnimalSim.State.autoFight = value
+    if value then
+        startFarmLoop()
+    else
+        stopFarmLoop()
+    end
+end
+
+local function auraLoop()
+    while auraActive do
+        local targetHumanoid = getClosestEnemyHumanoid()
+        if targetHumanoid then
+            hitHumanoid(targetHumanoid)
+        end
+        task.wait(0.1)
+    end
+end
+
+local function setAuraActive(value)
+    if auraActive == value then
+        return
+    end
+    auraActive = value
+    AnimalSim.State.killAura = value
+    if value and not auraTask then
+        auraTask = task.spawn(auraLoop)
+    elseif not value and auraTask then
+        while auraTask do
+            task.wait()
+        end
+        auraTask = nil
+    end
+end
+
+local function damageplayer(targetName)
+    local target = targetName and Players:FindFirstChild(targetName) or getClosestEnemyHumanoid()
+    if typeof(target) == "Instance" and target:IsA("Humanoid") then
+        hitHumanoid(target)
+        return true
+    end
+    if target and target.Character then
+        local humanoidInstance = target.Character:FindFirstChildOfClass("Humanoid")
+        if humanoidInstance then
+            hitHumanoid(humanoidInstance)
+            return true
+        end
+    end
+    return false
+end
+
+local function engageEnemy(enemyPlayer)
+    if not enemyPlayer then
+        return
+    end
+    local targetCharacter = enemyPlayer.Character
+    local targetHumanoid = targetCharacter and targetCharacter:FindFirstChildOfClass("Humanoid")
+    if not targetHumanoid then
+        return
+    end
+    if isInsideSafeZone(targetHumanoid.RootPart.Position) then
+        return
+    end
+    tryTeleportRoute(humanoid, targetHumanoid.RootPart.Position, {margin = 30})
+    followDynamicTarget(enemyPlayer, humanoid, {})
+    hitHumanoid(targetHumanoid)
+end
+
+local function findZoneTarget()
+    local character = LocalPlayer.Character
+    local localRoot = character and character:FindFirstChild("HumanoidRootPart")
+    if not localRoot then
+        return nil
+    end
+    local closestPlayer
+    local closestDistance = math.huge
+    for _, player in ipairs(Players:GetPlayers()) do
+        if player ~= LocalPlayer and not teamCheck(player.Name) then
+            local targetCharacter = player.Character
+            local targetHumanoid = targetCharacter and targetCharacter:FindFirstChildOfClass("Humanoid")
+            local targetRoot = targetCharacter and targetCharacter:FindFirstChild("HumanoidRootPart")
+            if targetHumanoid and targetHumanoid.Health > 0 and targetRoot then
+                if not isInsideSafeZone(targetRoot.Position) then
+                    local distance = (targetRoot.Position - localRoot.Position).Magnitude
+                    if distance < closestDistance then
+                        closestDistance = distance
+                        closestPlayer = player
+                    end
+                end
+            end
+        end
+    end
+    return closestPlayer
+end
+
+local function autoPVPLoop()
+    while autoPVPEnabled do
+        defineNilLocals()
+        local target = findClosestEnemy()
+        if target then
+            local ok, err = pcall(function()
+                if AnimalSim.State.autoFight then
+                    damageplayer(target.Name)
+                else
+                    engageEnemy(target)
+                end
+            end)
+            if not ok then
+                warn("[AnimalSim] auto PVP failed", err)
+            end
+        end
+        task.wait(AUTO_PVP_POLL_RATE)
+    end
+    autoPVPTask = nil
+end
+
+local function setAutoPVP(value)
+    if autoPVPEnabled == value then
+        return
+    end
+    autoPVPEnabled = value
+    AnimalSim.State.autoPVP = value
+    if value then
+        if not autoPVPTask then
+            autoPVPTask = task.spawn(autoPVPLoop)
+        end
+    else
+        while autoPVPTask do
+            task.wait()
+        end
+    end
+end
+
+local function autoZoneLoop(myToken)
+    while autoZoneEnabled and autoZoneCancelToken == myToken do
+        defineNilLocals()
+        local target = findZoneTarget()
+        if target then
+            local ok, err = pcall(function()
+                if AnimalSim.State.autoFight then
+                    damageplayer(target.Name)
+                else
+                    engageEnemy(target)
+                end
+            end)
+            if not ok then
+                warn("[AnimalSim] auto zone error", err)
+            end
+        elseif autoZoneBaseCF and humanoidRoot then
+            moveToTarget(autoZoneBaseCF.Position, humanoid, {arrivalDistance = 8})
+        end
+        task.wait(AUTO_ZONE_POLL_RATE)
+    end
+    if autoZoneBaseCF and humanoidRoot then
+        pcall(function()
+            humanoidRoot.CFrame = autoZoneBaseCF
+        end)
+    end
+    autoZoneTask = nil
+end
+
+local function setAutoZone(value)
+    if value then
+        if autoZoneEnabled then
+            return
+        end
+        defineNilLocals()
+        autoZoneEnabled = true
+        AnimalSim.State.autoZone = true
+        autoZoneCancelToken += 1
+        local character = LocalPlayer.Character
+        local rootPart = character and character:FindFirstChild("HumanoidRootPart")
+        if rootPart then
+            autoZoneBaseCF = rootPart.CFrame
+        end
+        local myToken = autoZoneCancelToken
+        autoZoneTask = task.spawn(function()
+            autoZoneLoop(myToken)
+        end)
+    else
+        if not autoZoneEnabled then
+            return
+        end
+        autoZoneEnabled = false
+        AnimalSim.State.autoZone = false
+        autoZoneCancelToken += 1
+        while autoZoneTask do
+            task.wait()
+        end
+        autoZoneBaseCF = nil
+    end
+end
+
+local function startAutoFlightChase()
+    if autoFlightChaseEnabled then
+        return
+    end
+    autoFlightChaseEnabled = true
+    AnimalSim.State.autoFlightChase = true
+    autoFlightChaseTask = task.spawn(function()
+        while autoFlightChaseEnabled do
+            local character = LocalPlayer.Character
+            local humanoidInstance = character and character:FindFirstChildOfClass("Humanoid")
+            local rootPart = character and character:FindFirstChild("HumanoidRootPart")
+            local camera = workspace.CurrentCamera
+            if character and humanoidInstance and rootPart and camera then
+                local targetPlayer = findClosestEnemy()
+                local targetRoot = targetPlayer and targetPlayer.Character and targetPlayer.Character:FindFirstChild("HumanoidRootPart")
+                if targetRoot then
+                    camera.CFrame = CFrame.lookAt(camera.CFrame.Position, targetRoot.Position)
+                    rootPart.CFrame = CFrame.lookAt(rootPart.Position, targetRoot.Position)
+                    humanoidInstance:Move(Vector3.new(0, 0, -1), true)
+                else
+                    humanoidInstance:Move(Vector3.new(), true)
+                end
+            end
+            task.wait(0.1)
+        end
+        autoFlightChaseTask = nil
+    end)
+end
+
+local function stopAutoFlightChase()
+    if not autoFlightChaseEnabled then
+        return
+    end
+    autoFlightChaseEnabled = false
+    AnimalSim.State.autoFlightChase = false
+    while autoFlightChaseTask do
+        task.wait()
+    end
+end
+
+AnimalSim.Modules.Utilities.teamCheck = teamCheck
+AnimalSim.Modules.Utilities.myTeam = myTeam
+AnimalSim.Modules.Utilities.findClosestPlayer = findClosestPlayer
+AnimalSim.Modules.Utilities.findClosestEnemy = findClosestEnemy
+AnimalSim.Modules.Utilities.PredictPlayerPosition = PredictPlayerPosition
+AnimalSim.Modules.Utilities.teleportInFrontOfPlayer = teleportInFrontOfPlayer
+AnimalSim.Modules.Utilities.increaseByPercentage = increaseByPercentage
+AnimalSim.Modules.Utilities.comparCash = comparCash
+AnimalSim.Modules.Utilities.conv = conv
+AnimalSim.Modules.Utilities.defineLocals = defineLocals
+AnimalSim.Modules.Utilities.defineNilLocals = defineNilLocals
+AnimalSim.Modules.Utilities.waitForChar = waitForChar
+AnimalSim.Modules.Utilities.waitDoneMove = waitDoneMove
+AnimalSim.Modules.Utilities.getClosest = getClosest
+AnimalSim.Modules.Utilities.getPos = getPos
+AnimalSim.Modules.Utilities.stayNearPlayer = stayNearPlayer
+AnimalSim.Modules.Utilities.setFollowTarget = setFollowTargetEnabled
+AnimalSim.Modules.Utilities.isInsideSafeZone = isInsideSafeZone
+AnimalSim.Modules.Utilities.registerTeleporter = registerTeleporter
+AnimalSim.Modules.Utilities.useTeleporter = useTeleporter
+AnimalSim.Modules.Utilities.clearTeleporters = clearTeleporters
+
+AnimalSim.Modules.Pathing.moveToTarget = moveToTarget
+AnimalSim.Modules.Pathing.followDynamicTarget = followDynamicTarget
+AnimalSim.Modules.Pathing.tryTeleportRoute = tryTeleportRoute
+
+AnimalSim.Modules.Combat.toggleFarm = setFarmActive
+AnimalSim.Modules.Combat.toggleAura = setAuraActive
+AnimalSim.Modules.Combat.farm = startFarmLoop
+AnimalSim.Modules.Combat.farmPassive = farmPassive
+AnimalSim.Modules.Combat.stopFarm = stopFarmLoop
+AnimalSim.Modules.Combat.damageplayer = damageplayer
+AnimalSim.Modules.Combat.engageEnemy = engageEnemy
+AnimalSim.Modules.Combat.startAutoEat = startAutoEat
+AnimalSim.Modules.Combat.stopAutoEat = stopAutoEat
+AnimalSim.Modules.Combat.startAutoFireball = startAutoFireball
+AnimalSim.Modules.Combat.stopAutoFireball = stopAutoFireball
+AnimalSim.Modules.Combat.startAutoFlightChase = startAutoFlightChase
+AnimalSim.Modules.Combat.stopAutoFlightChase = stopAutoFlightChase
+AnimalSim.Modules.Combat.setLegitMode = setLegitMode
+AnimalSim.Modules.Combat.setAutoJump = setAutoJump
+AnimalSim.Modules.Combat.setAutoFight = setAutoFight
+AnimalSim.Modules.Combat.setAutoPVP = setAutoPVP
+AnimalSim.Modules.Combat.setAutoZone = setAutoZone
+
+---------------------------------------------------------------------
+-- Logging helpers
+---------------------------------------------------------------------
+
+local selectedPlayers = {
+    "notime4crazy", "282475249a7auto", "9", "Allaboutsuki", "DefNotRealMe",
+    "Doornextguythat", "Little_Puppywolf", "ProGammerMove_1", "RektBySuki",
+    "RektBySukisAlt", "Rockyrode112", "Rose_altl5", "Sakura_Mirai",
+    "SimpleDisasters", "TheBestAccount_mom", "TheFreeAccount_Free1",
+    "TheOneMyth", "Unicornzzz6109", "baby46793", "batman_kite",
+    "foalsarecut", "iwillendUmadaf4", "Miner_havennoob", "naypolm",
+    "naypolm005", "naypolm05", "naypolm12", "naypolm1789", "qwertyPCLOL",
+    "ll_BANX", "xXxnothingxXx274", "dexvilxtails", "ninja1098583",
+    "J_esusTheCreator", "L_ilBoomStick", "TheReal_SigmaG",
+    "SpongeBobStartFish", "HeyNo_ThatsBa", "PeanutNox2180", "Tsubakidoki",
+}
+
+local initialHealth = {}
+
+local function LogDamage(player, damageAmount)
+    if damageAmount < 0 then
+        damageAmount = -damageAmount
+    end
+    print(player.Name .. " took " .. damageAmount .. " damage")
+    local humanoidInstance = getClosestEnemyHumanoid()
+    if humanoidInstance then
+        hitHumanoid(humanoidInstance)
+    end
+end
+
+local function LogEvent(player, event)
+    print(player.Name .. " " .. event)
+end
+
+local function ConnectHealthChanged(player)
+    local function bind()
+        repeat task.wait() until player.Character and player.Character:FindFirstChild("Humanoid")
+        local humanoidInstance = player.Character:FindFirstChild("Humanoid")
+        if not humanoidInstance then
+            return
+        end
+        initialHealth[player] = humanoidInstance.Health
+        humanoidInstance:GetPropertyChangedSignal("Health"):Connect(function()
+            local current = humanoidInstance.Health
+            local previous = initialHealth[player] or current
+            LogDamage(player, previous - current)
+            LogEvent(player, "health changed by " .. (previous - current))
+            initialHealth[player] = current
+        end)
+    end
+    task.spawn(bind)
+end
+
+AnimalSim.Modules.Logging.selectedPlayers = selectedPlayers
+AnimalSim.Modules.Logging.LogDamage = LogDamage
+AnimalSim.Modules.Logging.LogEvent = LogEvent
+AnimalSim.Modules.Logging.ConnectHealthChanged = ConnectHealthChanged
+AnimalSim.Modules.Logging.initialHealth = initialHealth
+
+---------------------------------------------------------------------
+-- UI helpers
+---------------------------------------------------------------------
+
+local function buildUI()
+    local venyx = loadstring(game:HttpGet("https://raw.githubusercontent.com/Stefanuk12/Venyx-UI-Library/main/source2.lua"))()
+    local ui = venyx.new({title = "Revamp - Animal Simulator"})
+
+    local gameplayPage = ui:addPage({title = "Animal Sim"})
+    local gameplaySection = gameplayPage:addSection({title = "Gameplay"})
+
+    local playerOptions = {}
+    for _, player in ipairs(Players:GetPlayers()) do
+        if player ~= LocalPlayer then
+            table.insert(playerOptions, player.Name)
+        end
+    end
+
+    gameplaySection:addDropdown({
+        title = "Set Target Player",
+        list = playerOptions,
+        callback = function(playerName)
+            AnimalSim.State.selectedPlayer = Players:FindFirstChild(playerName)
+        end,
+    })
+
+    gameplaySection:addToggle({
+        title = "Auto EXP Farm",
+        toggled = farmActive,
+        callback = setFarmActive,
+    })
+
+    gameplaySection:addToggle({
+        title = "Legit Mode",
+        toggled = AnimalSim.State.legitMode,
+        callback = setLegitMode,
+    })
+
+    gameplaySection:addToggle({
+        title = "Kill aura",
+        toggled = AnimalSim.State.killAura,
+        callback = setAuraActive,
+    })
+
+    gameplaySection:addToggle({
+        title = "Auto PVP",
+        toggled = AnimalSim.State.autoPVP,
+        callback = setAutoPVP,
+    })
+
+    gameplaySection:addToggle({
+        title = "Auto Jump",
+        toggled = AnimalSim.State.autoJump,
+        callback = setAutoJump,
+    })
+
+    gameplaySection:addToggle({
+        title = "Auto Eat",
+        toggled = autoEatEnabled,
+        callback = function(value)
+            if value then
+                startAutoEat()
+            else
+                stopAutoEat()
+            end
+        end,
+    })
+
+    gameplaySection:addToggle({
+        title = "Auto Fight",
+        toggled = AnimalSim.State.autoFight,
+        callback = setAutoFight,
+    })
+
+    gameplaySection:addToggle({
+        title = "autoFireball",
+        toggled = autoFireballEnabled,
+        callback = function(value)
+            if value then
+                startAutoFireball()
+            else
+                stopAutoFireball()
+            end
+        end,
+    })
+
+    gameplaySection:addToggle({
+        title = "Auto Zone",
+        toggled = AnimalSim.State.autoZone,
+        callback = setAutoZone,
+    })
+
+    gameplaySection:addToggle({
+        title = "Flight Chase",
+        toggled = autoFlightChaseEnabled,
+        callback = function(value)
+            if value then
+                startAutoFlightChase()
+            else
+                stopAutoFlightChase()
+            end
+        end,
+    })
+
+    gameplaySection:addToggle({
+        title = "Use target",
+        toggled = AnimalSim.State.followTarget,
+        callback = setFollowTargetEnabled,
+    })
+
+    gameplaySection:addButton({
+        title = "Damage Player",
+        callback = function()
+            if AnimalSim.State.selectedPlayer then
+                damageplayer(AnimalSim.State.selectedPlayer.Name)
+            else
+                damageplayer()
+            end
+        end,
+    })
+
+    local themePage = ui:addPage({title = "Theme"})
+    local colorsSection = themePage:addSection({title = "Colors"})
+    for theme, color in pairs({
+        Background = Color3.fromRGB(24, 24, 24),
+        Glow = Color3.fromRGB(0, 0, 0),
+        Accent = Color3.fromRGB(10, 10, 10),
+        LightContrast = Color3.fromRGB(20, 20, 20),
+        DarkContrast = Color3.fromRGB(14, 14, 14),
+        TextColor = Color3.fromRGB(255, 255, 255),
+    }) do
+        colorsSection:addColorPicker({
+            title = theme,
+            default = color,
+            callback = function(newColor)
+                venyx:setTheme(theme, newColor)
+            end,
+        })
+    end
+
+    AnimalSim.UI.instances.library = venyx
+    AnimalSim.UI.instances.ui = ui
+
+    return ui
+end
+
+---------------------------------------------------------------------
+-- Initialisation
+---------------------------------------------------------------------
+
+function AnimalSim.init()
+    if game.PlaceId ~= AnimalSim.PlaceId then
+        return
+    end
+    defineLocals()
+    hptp()
+    clearTeleporters()
+    for name, config in pairs(AnimalSim.Data.Teleporters) do
+        registerTeleporter(name, config)
+    end
+    local ui = buildUI()
+    if ui then
+        ui:SelectPage(1)
+    end
+end
+
+return AnimalSim
+


### PR DESCRIPTION
## Summary
- add race pad discovery utilities and cached state back into the Legend of Speed split
- reintroduce the auto race loop, toggle wiring, and join helper alongside the existing automation
- expose a UI section for refreshing race pads and enabling auto race

## Testing
- not run (Lua interpreter unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68eedb334c48832abe6bd383123265b6